### PR TITLE
Improve build and update conditions

### DIFF
--- a/etos/CHANGELOG.md
+++ b/etos/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.1.0
+
+- Move `setState` and `getState` to `EventHandler` methods.
+- Add `callWhen` to allow `EventHandlers` to only be called in certain conditions.
+- Remove option to use functions as `EventHandlers`.
+
 ## 0.0.2
 
 - Remove unneeded casts.

--- a/etos/CHANGELOG.md
+++ b/etos/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Move `setState` and `getState` to `EventHandler` methods.
 - Add `callWhen` to allow `EventHandlers` to only be called in certain conditions.
+- Add `dispatch` to `EventHandler` to easily dispatch new `Events`.
 - Remove option to use functions as `EventHandlers`.
 
 ## 0.0.2

--- a/etos/lib/src/etos.dart
+++ b/etos/lib/src/etos.dart
@@ -28,6 +28,11 @@ abstract class EventHandler<Tstate extends Object, Tevent> {
     _etos!._setState(state);
   }
 
+  void dispatch(Object event) {
+    assert(_etos != null, _notLinkedError);
+    _etos!.dispatch(event);
+  }
+
   /// Decide if this EventHandler can be called based on the current state.
   ///
   /// Return true if you want this EventHandler to be called, else false.

--- a/etos/pubspec.yaml
+++ b/etos/pubspec.yaml
@@ -1,7 +1,7 @@
 name: etos
 description: 
   An event-driven state management solution.
-version: 0.0.2
+version: 0.1.0
 repository: https://github.com/SEGVeenstra/etos
 # homepage: https://www.example.com
 

--- a/etos_flutter/CHANGELOG.md
+++ b/etos_flutter/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.0
+
+- Add `buildWhen` to `StateBuilder`.
+- Update dependency on `etos`.
+
 ## 0.0.3
 
 - Made old state non-nullable in StateListener.

--- a/etos_flutter/lib/src/etos_provider.dart
+++ b/etos_flutter/lib/src/etos_provider.dart
@@ -44,4 +44,5 @@ class _InheritedEtos extends InheritedWidget {
 extension EtosExt on BuildContext {
   void dispatch(Object event) => EtosProvider.of(this).dispatch(event);
   Etos<T> of<T extends Object>() => EtosProvider.of<T>(this);
+  Etos<T> state<T extends Object>() => EtosProvider.of<T>(this);
 }

--- a/etos_flutter/lib/src/state_builder.dart
+++ b/etos_flutter/lib/src/state_builder.dart
@@ -8,19 +8,23 @@ class StateBuilder<Tstate extends Object, Tvalue extends Object?>
     this.etos,
     required this.builder,
     required this.converter,
+    this.buildWhen,
     super.key,
   });
 
   final Etos<Tstate>? etos;
   final Widget Function(BuildContext context, Tvalue value) builder;
   final Converter<Tstate, Tvalue> converter;
+  final bool Function(Tstate state)? buildWhen;
 
   @override
   Widget build(BuildContext context) {
     final etosToUse = etos ?? EtosProvider.of(context) as Etos<Tstate>;
 
     return StreamBuilder<Tvalue>(
-      stream: etosToUse.states.map(converter),
+      stream: etosToUse.states
+          .where((state) => buildWhen?.call(state) ?? true)
+          .map(converter),
       initialData: converter(etosToUse.state),
       builder: (context, snapshot) => builder(
         context,

--- a/etos_flutter/pubspec.yaml
+++ b/etos_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: etos_flutter
 description: Helper widgets for Etos
-version: 0.0.3
+version: 0.1.0
 repository: https://github.com/SEGVeenstra/etos
 
 environment:
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  etos: ^0.0.2
+  etos: ^0.1.0
 
 dev_dependencies:
   flutter_test:

--- a/examples/counter_cli/bin/counter_cli.dart
+++ b/examples/counter_cli/bin/counter_cli.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:etos/etos.dart';
 import 'package:logging/logging.dart';
 
@@ -11,26 +13,56 @@ class DecrementEvent {
   String toString() => 'DecrementEvent';
 }
 
+class IncrementEventHandler extends EventHandler<int, IncrementEvent> {
+  @override
+  FutureOr<void> call(IncrementEvent event) {
+    // Use setState and getState to work with state
+    setState(getState() + 1);
+  }
+}
+
+class DecrementEventHandler extends EventHandler<int, DecrementEvent> {
+  // You can override the callWhen method
+  @override
+  bool callWhen(int state) => state > 0;
+
+  @override
+  FutureOr<void> call(DecrementEvent event) {
+    setState(getState() - 1);
+  }
+}
+
 void main() {
   // Setup logger
   Logger.root.onRecord.listen((event) {
-    print(event);
+    // Etos usses the Logging package to log usefull information like
+    // State updates and Events that are being emitted!
+    print('[' +
+        event.level.name +
+        '] ' +
+        event.loggerName +
+        ': ' +
+        event.message);
   });
 
   final etos = Etos<int>(state: 0);
 
   etos.states.listen((state) {
-    //print(state);
+    // Here you can use the state!
   });
 
-  etos.on<IncrementEvent>((event, get, set) => set(get() + 1));
-  etos.on<DecrementEvent>((event, get, set) => set(get() - 1));
+  etos.on<IncrementEvent>(IncrementEventHandler());
+  etos.on<DecrementEvent>(DecrementEventHandler());
 
-  // Is being ignored (warning logged)
-  etos.on<IncrementEvent>((event, get, set) => set(get() + 1));
+  // Is being ignored because IncrementEvent already has an EventHandler (warning logged)
+  etos.on<IncrementEvent>(IncrementEventHandler());
 
-  etos.dispatch(IncrementEvent());
-  etos.dispatch(IncrementEvent());
-  etos.dispatch(DecrementEvent());
-  etos.dispatch(IncrementEvent());
+  etos.dispatch(IncrementEvent()); // 1
+  etos.dispatch(IncrementEvent()); // 2
+  etos.dispatch(DecrementEvent()); // 1
+  etos.dispatch(IncrementEvent()); // 2
+  etos.dispatch(DecrementEvent()); // 1
+  etos.dispatch(DecrementEvent()); // 0
+  etos.dispatch(
+      DecrementEvent()); // Ignorred because of the `callWhen`-condition!
 }

--- a/examples/counter_cli/pubspec.lock
+++ b/examples/counter_cli/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       path: "../../etos"
       relative: true
     source: path
-    version: "0.0.1"
+    version: "0.0.2"
   lints:
     dependency: "direct dev"
     description:

--- a/examples/counter_flutter/lib/main.dart
+++ b/examples/counter_flutter/lib/main.dart
@@ -9,16 +9,18 @@ class DecrementEvent {}
 // Create [EventHandlers]
 // EventHandlers are intended to contain the business logic of your application.
 
-// An [EventHandlers] can be a function:
-void increment(IncrementEvent event, StateGetter<int> get,
-        StateSetter<int> set) async =>
-    set(get() + 1);
-
-// Or even class:
-class DecrementHandler extends EventHandler<int, DecrementEvent> {
+// Extends the EventHandler class and pass the Tstate and Tevent type params
+class IncrementEventHandler extends EventHandler<int, IncrementEvent> {
   @override
-  void call(DecrementEvent event, StateGetter<int> getState,
-      StateSetter<int> setState) {
+  void call(IncrementEvent event) {
+    // Uses the setState and getState methods to work with state.
+    setState(getState() + 1);
+  }
+}
+
+class DecrementEventHandler extends EventHandler<int, DecrementEvent> {
+  @override
+  void call(DecrementEvent event) {
     setState(getState() - 1);
   }
 }
@@ -26,8 +28,8 @@ class DecrementHandler extends EventHandler<int, DecrementEvent> {
 // Create an [Etos] instance
 final etos = Etos(state: 0)
   // Add the [EventHandler]s for each event
-  ..on<IncrementEvent>(increment)
-  ..on<DecrementEvent>(DecrementHandler());
+  ..on<IncrementEvent>(IncrementEventHandler())
+  ..on<DecrementEvent>(DecrementEventHandler());
 
 void main() {
   runApp(const MyApp());
@@ -38,7 +40,7 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // Optionally you can wrap your application in an EtosProvider.
+    // You can wrap your application in an EtosProvider.
     // This will make it possible to get the Etos from context using
     // EtosProvider.of(context) and it will
     // make the other convinient widgets like EtosBuilder find the Etos

--- a/examples/counter_flutter/pubspec.lock
+++ b/examples/counter_flutter/pubspec.lock
@@ -49,14 +49,14 @@ packages:
       path: "../../etos"
       relative: true
     source: path
-    version: "0.0.1"
+    version: "0.0.2"
   etos_flutter:
     dependency: "direct main"
     description:
       path: "../../etos_flutter"
       relative: true
     source: path
-    version: "0.0.2"
+    version: "0.0.3"
   fake_async:
     dependency: transitive
     description:

--- a/examples/todo_flutter/lib/event_handlers/add_todo_event_handler.dart
+++ b/examples/todo_flutter/lib/event_handlers/add_todo_event_handler.dart
@@ -5,8 +5,7 @@ import '../state/app_state.dart';
 
 class AddTodoEventHandler extends EventHandler<AppState, AddTodoEvent> {
   @override
-  void call(AddTodoEvent event, StateGetter<AppState> getState,
-      StateSetter<AppState> setState) {
+  void call(AddTodoEvent event) {
     final currentState = getState();
 
     // We can only add todos if we are authenticated, so let's check that first.

--- a/examples/todo_flutter/lib/event_handlers/load_todos_event_handler.dart
+++ b/examples/todo_flutter/lib/event_handlers/load_todos_event_handler.dart
@@ -7,11 +7,7 @@ import 'package:todo_flutter/state/app_state.dart';
 
 class LoadTodosEventHandler extends EventHandler<AppState, LoadTodosEvent> {
   @override
-  FutureOr<void> call(
-    LoadTodosEvent event,
-    StateGetter<AppState> getState,
-    StateSetter<AppState> setState,
-  ) async {
+  FutureOr<void> call(LoadTodosEvent event) async {
     // get the current state
     final currentState = getState();
     if (currentState is! AuthenticatedState) return;

--- a/examples/todo_flutter/lib/event_handlers/login_handler.dart
+++ b/examples/todo_flutter/lib/event_handlers/login_handler.dart
@@ -3,9 +3,9 @@ import 'package:todo_flutter/events/login_event.dart';
 
 import '../state/app_state.dart';
 
-class LoginHandler {
-  void call(LoginEvent event, StateGetter<AppState> getState,
-      StateSetter<AppState> setState) async {
+class LoginHandler extends EventHandler<AppState, LoginEvent> {
+  @override
+  void call(LoginEvent event) async {
     var currentState = getState();
 
     // We first check if we are in an unauthenticated state

--- a/examples/todo_flutter/lib/event_handlers/logout_handler.dart
+++ b/examples/todo_flutter/lib/event_handlers/logout_handler.dart
@@ -2,8 +2,9 @@ import 'package:etos_flutter/etos_flutter.dart';
 import 'package:todo_flutter/events/logout_event.dart';
 import 'package:todo_flutter/state/app_state.dart';
 
-class LogoutHandler {
-  void call(LogoutEvent event, _, StateSetter<AppState> set) {
-    set(UnauthenticatedAppState());
+class LogoutHandler extends EventHandler<AppState, LogoutEvent> {
+  @override
+  void call(LogoutEvent event) {
+    setState(UnauthenticatedAppState());
   }
 }

--- a/examples/todo_flutter/lib/event_handlers/select_todo_event_handler.dart
+++ b/examples/todo_flutter/lib/event_handlers/select_todo_event_handler.dart
@@ -5,8 +5,7 @@ import '../events/select_todo_event.dart';
 
 class SelectTodoEventHandler extends EventHandler<AppState, SelectTodoEvent> {
   @override
-  void call(SelectTodoEvent event, StateGetter<AppState> getState,
-      StateSetter<AppState> setState) {
+  void call(SelectTodoEvent event) {
     final currentState = getState();
 
     // This can only be done by an authenticated user

--- a/examples/todo_flutter/lib/event_handlers/unselect_todo_event_handler.dart
+++ b/examples/todo_flutter/lib/event_handlers/unselect_todo_event_handler.dart
@@ -5,12 +5,12 @@ import 'package:todo_flutter/state/app_state.dart';
 class UnselectTodoEventHandler
     extends EventHandler<AppState, UnselectTodoEvent> {
   @override
-  void call(UnselectTodoEvent event, StateGetter<AppState> getState,
-      StateSetter<AppState> setState) {
-    final currentState = getState();
+  bool callWhen(AppState state) => state is AuthenticatedState;
 
-    // This action can only be done when the user is authenticated.
-    if (currentState is! AuthenticatedState) return;
+  @override
+  void call(UnselectTodoEvent event) {
+    // We can force-cast the event because of the `callWhen` method.
+    final currentState = getState() as AuthenticatedState;
 
     setState(currentState.clearSelectedTodo());
   }

--- a/examples/todo_flutter/lib/helpers/object_ext.dart
+++ b/examples/todo_flutter/lib/helpers/object_ext.dart
@@ -3,4 +3,6 @@ extension ObjectExt on Object {
     if (this is T) return this as T;
     return null;
   }
+
+  T cast<T>() => this as T;
 }

--- a/examples/todo_flutter/lib/pages/todos_page.dart
+++ b/examples/todo_flutter/lib/pages/todos_page.dart
@@ -48,10 +48,11 @@ class _TodosPageState extends State<TodosPage> {
               );
             }
 
-            return StateBuilder<AppState, List<Todo>?>(
-              converter: (state) => state.tryCast<AuthenticatedState>()?.todos,
+            return StateBuilder<AppState, List<Todo>>(
+              buildWhen: (state) => state is AuthenticatedState,
+              converter: (state) => state.cast<AuthenticatedState>().todos,
               builder: (context, todos) => ListView(
-                children: (todos ?? [])
+                children: (todos)
                     .map(
                       (todo) => ListTile(
                         title: Text(todo.description),

--- a/examples/todo_flutter/pubspec.lock
+++ b/examples/todo_flutter/pubspec.lock
@@ -56,14 +56,14 @@ packages:
       path: "../../etos"
       relative: true
     source: path
-    version: "0.0.1"
+    version: "0.0.2"
   etos_flutter:
     dependency: "direct main"
     description:
       path: "../../etos_flutter"
       relative: true
     source: path
-    version: "0.0.2"
+    version: "0.0.3"
   fake_async:
     dependency: transitive
     description:


### PR DESCRIPTION
**ETOS**
This PR will required the Handlers passed to `Etos.on<T>()` to always extend `EventHandler`, thus removing the option to pass functions.
It also adds a `callWhen` method to `EventHandlers` to allow you to tell `EventHandlers` to only run in certain conditions.
The functions `setState`, `getState` and `dispatch` have been added to `EventHandlers`.

**ETOS FLUTTER**
Add `buildWhen` to `StateBuilder`.